### PR TITLE
Fix legolas_env.yaml to use cuda-toolkit meta-package for CUDA 11.8

### DIFF
--- a/legolas_env.yaml
+++ b/legolas_env.yaml
@@ -1,9 +1,11 @@
 name: legolas
 channels:
   - nodefaults
+  - nvidia/label/cuda-11.8.0
   - nvidia
   - pytorch
   - conda-forge
+
 dependencies:
   - python=3.10
   - pip>=24.0
@@ -11,22 +13,12 @@ dependencies:
 
   # PyTorch (built against CUDA 11.8)
   - pytorch=2.5.1
-  - pytorch-cuda=11.8
+  - pytorch-cuda=11.8.*
 
   # ────────────   CUDA 11.8 developer toolkit  ────────────
-  # Everything in this block is only needed if you want CUDA/cuAEV
-  # To run on CPU only, comment out all of these lines:
-  - nvidia::cuda-cudart=11.8.89
-  - nvidia::cuda-cudart-dev=11.8.89
-  - nvidia::cuda-cudart-static=11.8.89
-  - nvidia::cuda-libraries=11.8.0
-  - nvidia::cuda-libraries-dev=11.8.0
-  - nvidia::cuda-nvcc=11.8.89
-  - nvidia::cuda-nvrtc=11.8.89
-  - nvidia::cuda-nvrtc-dev=11.8.89
-  - nvidia::cuda-cupti=11.8.87
-  - nvidia::cuda-nvtx=11.8.86
-  - nvidia::cuda-cccl=11.8.89
+  # This block is only needed if you want CUDA/cuAEV
+  # To run on CPU only, comment out the following line:
+  - nvidia/label/cuda-11.8.0::cuda-toolkit=11.8.*
 
   # C/C++ toolchain
   - gcc_linux-64=11.4.*


### PR DESCRIPTION
This simplifies the environment file a bit and adds a new channel (nvidia/label/cuda-11.8.0).

Tested on HiPerGator and Moria, example `A001_1KF3A.pdbH` runs as expected.