### PR TITLE
Add support for HDF5 trajectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ python legolas.py data/A001_1KF3A.pdbH -atype H,C,N
 # Run on molecular dynamics trajectory:
 python legolas.py data/{trajectory_file}.nc -t data/{topology_file}.parm7
 
+# For trajectories, Legolas also supports the HDF5 (.h5) format, with no topology needed.
+
 # Specify output file type ("csv", "parquet", "pdbcs", "all", default=all)
 # pdbcs output file type is only available for PDB inputs (not trajectories)
 python legolas.py data/A001_1KF3A.pdbH -o csv,pdbcs

--- a/test/legolas.py
+++ b/test/legolas.py
@@ -512,6 +512,10 @@ if __name__ == "__main__":
             if args.topology is None:
                 raise ValueError("Topology file is required for trajectory files")
             entry = load_and_validate_file(input_file, topology=args.topology, TRAJECTORY=True)
+        elif file_extension.lower() == '.h5':
+            entry = load_and_validate_file(input_file, TRAJECTORY=True)
+        else:
+            raise ValueError('Inputs are expected to be .pdb*, .nc, or .h5 files.')
 
         # Run LEGOLAS
         entry = entry.to(device)


### PR DESCRIPTION
I added support for using Legolas on HDF5 (.h5) MD trajectories. I also added a line of code to raise an exception and tell users what the expected file input types are if their input is not .pdb*, .h5, or .nc. Thanks!